### PR TITLE
Update to remarkable-update-image 1.3.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,70 +130,70 @@ jobs:
           name: rmufuse-alpine
           path: dist
           if-no-files-found: error
-  build-executable-remarkable:
-    name: Build binary for reMarkable
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the Git repository
-        uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-          cache: "pip"
-      - name: Nuitka ccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.nuitka
-          key: ${{ github.job }}-ccache-remarkable-2.15.1
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build with nuitka
-        run: |
-          set -e
-          ./make_for_remarkable.sh portable \
-          | while read -r line; do
-            if [[ "$line" == 'Nuitka'*':ERROR:'* ]] || [[ "$line" == "ERROR:"* ]]; then
-              echo "::error file=${{ steps.args.outputs.main_file }},title=Nuitka Error::$line"
-            elif [[ "$line" == 'Nuitka'*':WARNING:'* ]] || [[ "$line" == "WARNING:"* ]]; then
-              echo "::warning file=${{ steps.args.outputs.main_file }},title=Nuitka Warning::$line"
-            elif [[ "$line" == 'Nuitka:INFO:'* ]] || [[ "$line" == "INFO:"* ]]; then
-              echo "$line"
-            else
-              echo "::debug::$line"
-            fi
-          done
-          sudo mv dist/rmufuse-portable dist/rmufuse-remarkable
-        working-directory: ${{ github.workspace }}
-      - uses: actions/upload-artifact@v6
-        with:
-          name: rmufuse-remarkable
-          path: dist
-          if-no-files-found: error
-      - name: Free up space
-        run: |
-          export DEBIAN_FRONTEND="noninteractive"
-          sudo apt-get autoremove -y
-          sudo apt-get autoclean -y
-          sudo rm -rf \
-            /usr/lib/jvm \
-            /usr/share/dotnet \
-            /usr/share/swift \
-            /usr/local/.ghcup \
-            /usr/local/julia* \
-            /usr/local/lib/android \
-            /usr/local/share/chromium \
-            /opt/microsoft /opt/google \
-            /opt/az \
-            /usr/local/share/powershell
-      - name: Sanity check
-        uses: Eeems-Org/run-in-remarkable-action@v1
-        with:
-          fw_version: 2.15.1
-          run: ./rmufuse-remarkable --help
-          path: dist
+  # build-executable-remarkable:
+  #   name: Build binary for reMarkable
+  #   needs: [test]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout the Git repository
+  #       uses: actions/checkout@v6
+  #     - uses: actions/setup-python@v6
+  #       with:
+  #         python-version: "3.11"
+  #         cache: "pip"
+  #     - name: Nuitka ccache
+  #       uses: actions/cache@v5
+  #       with:
+  #         path: ${{ github.workspace }}/.nuitka
+  #         key: ${{ github.job }}-ccache-remarkable-2.15.1
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     - name: Build with nuitka
+  #       run: |
+  #         set -e
+  #         ./make_for_remarkable.sh portable \
+  #         | while read -r line; do
+  #           if [[ "$line" == 'Nuitka'*':ERROR:'* ]] || [[ "$line" == "ERROR:"* ]]; then
+  #             echo "::error file=${{ steps.args.outputs.main_file }},title=Nuitka Error::$line"
+  #           elif [[ "$line" == 'Nuitka'*':WARNING:'* ]] || [[ "$line" == "WARNING:"* ]]; then
+  #             echo "::warning file=${{ steps.args.outputs.main_file }},title=Nuitka Warning::$line"
+  #           elif [[ "$line" == 'Nuitka:INFO:'* ]] || [[ "$line" == "INFO:"* ]]; then
+  #             echo "$line"
+  #           else
+  #             echo "::debug::$line"
+  #           fi
+  #         done
+  #         sudo mv dist/rmufuse-portable dist/rmufuse-remarkable
+  #       working-directory: ${{ github.workspace }}
+  #     - uses: actions/upload-artifact@v6
+  #       with:
+  #         name: rmufuse-remarkable
+  #         path: dist
+  #         if-no-files-found: error
+  #     - name: Free up space
+  #       run: |
+  #         export DEBIAN_FRONTEND="noninteractive"
+  #         sudo apt-get autoremove -y
+  #         sudo apt-get autoclean -y
+  #         sudo rm -rf \
+  #           /usr/lib/jvm \
+  #           /usr/share/dotnet \
+  #           /usr/share/swift \
+  #           /usr/local/.ghcup \
+  #           /usr/local/julia* \
+  #           /usr/local/lib/android \
+  #           /usr/local/share/chromium \
+  #           /opt/microsoft /opt/google \
+  #           /opt/az \
+  #           /usr/local/share/powershell
+  #     - name: Sanity check
+  #       uses: Eeems-Org/run-in-remarkable-action@v1
+  #       with:
+  #         fw_version: 2.15.1
+  #         run: ./rmufuse-remarkable --help
+  #         path: dist
   build-wheel:
     name: Build wheel with python ${{ matrix.python }}
     needs: [test]
@@ -302,7 +302,7 @@ jobs:
     needs:
       - build-executable-ubuntu
       - build-executable-alpine
-      - build-executable-remarkable
+      # - build-executable-remarkable
       - build-wheel
       - build-any-wheel
       - build-sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,10 @@ jobs:
           path: ${{ github.workspace }}/.nuitka
           key: ${{ github.job }}-ccache-ubuntu-latest
       - name: Build with nuitka
-        run: make executable
+        run: |
+          set -e
+          make executable
+          mv dist/rmufuse dist/rmufuse-ubuntu
       - uses: actions/upload-artifact@v6
         with:
           name: rmufuse-ubuntu
@@ -125,7 +128,9 @@ jobs:
       - name: Build with nuitka
         shell: alpine.sh {0}
         run: |
+          set -e
           make executable
+          mv dist/rmufuse dist/rmufuse-alpine
       - uses: actions/upload-artifact@v6
         with:
           name: rmufuse-alpine
@@ -166,6 +171,7 @@ jobs:
               echo "::debug::$line"
             fi
           done
+          mv dist/rmufuse-portable dist/rmufuse-remarkable
         working-directory: ${{ github.workspace }}
       - uses: actions/upload-artifact@v6
         with:
@@ -192,7 +198,7 @@ jobs:
         uses: Eeems-Org/run-in-remarkable-action@v1
         with:
           fw_version: 2.15.1
-          run: ./rmufuse-portable --help
+          run: ./rmufuse-remarkable --help
           path: dist
   build-wheel:
     name: Build wheel with python ${{ matrix.python }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
               echo "::debug::$line"
             fi
           done
-          mv dist/rmufuse-portable dist/rmufuse-remarkable
+          sudo mv dist/rmufuse-portable dist/rmufuse-remarkable
         working-directory: ${{ github.workspace }}
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Debug flags
-        shell: bash
-        if: runner.debug == '1'
-        run: echo 'FLAGS=-d' >> "$GITHUB_ENV"
       - name: Checkout the Git repository
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,11 +64,9 @@ jobs:
     steps:
       - name: Install Apt packages
         id: cache-apt
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: Eeems-Org/apt-cache-action@v1
         with:
-          execute_install_scripts: true
           packages: libfuse-dev ccache
-          version: 1.0
       - name: Checkout the Git repository
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -224,7 +218,7 @@ jobs:
           dnf -y install fuse-devel
           cd /src;
           export PATH=\$PATH:/opt/python/$python_version-$python_version/bin;
-          make ${{ env.FLAGS }} native-wheel;
+          make native-wheel;
           auditwheel repair dist/*.whl;
           EOF
           )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,14 +312,26 @@ jobs:
       - name: Checkout the Git repository
         uses: actions/checkout@v6
       - name: Download pip packages
-        id: download
+        id: download-pip
         uses: actions/download-artifact@v8
         with:
           pattern: pip-*
+          merge-multiple: true
+      - name: Download pip packages
+        id: download-rmufuse
+        uses: actions/download-artifact@v8
+        with:
+          pattern: rmufuse-*
           merge-multiple: true
       - name: Upload to release
         run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
-        working-directory: ${{ steps.download.outputs.download-path }}
+        working-directory: ${{ steps.download-pip.outputs.download-path }}
+      - name: Upload to release
+        run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        working-directory: ${{ steps.download-rmufuse.outputs.download-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,7 +297,7 @@ jobs:
           packages-dir: ${{ steps.download.outputs.download-path }}
           skip-existing: true
   release:
-    name: Add ${{ matrix.artifact }} to release
+    name: Add files to release
     if: github.repository == 'Eeems-Org/remarkable-update-fuse' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
     needs:
       - build-executable-ubuntu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,14 +221,16 @@ jobs:
           python_version=${{ matrix.python }}
           python_version=cp${python_version//.}
           script=$(cat <<EOF
-          dnf install fuse-devel
+          dnf -y install fuse-devel
           cd /src;
           export PATH=\$PATH:/opt/python/$python_version-$python_version/bin;
           make ${{ env.FLAGS }} native-wheel;
           auditwheel repair dist/*.whl;
           EOF
           )
-          docker run -v $(pwd):/src \
+          docker run \
+            --rm \
+            --volume=$(pwd):/src \
             quay.io/pypa/manylinux_2_34_x86_64:latest \
             /bin/bash -c "$script"
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python:
+        python: &python-versions
           - "3.11"
           - "3.12"
           - "3.13"
@@ -27,13 +27,13 @@ jobs:
           packages: libfuse-dev
           version: 1.0
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
       - name: Cache test files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .venv/bin/codexctl.bin
@@ -58,19 +58,19 @@ jobs:
           packages: libfuse-dev ccache
           version: 1.0
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
       - name: Nuitka ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.nuitka
           key: ${{ github.job }}-ccache-ubuntu-latest
       - name: Build with nuitka
         run: make executable
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: rmufuse-ubuntu
           path: dist
@@ -85,7 +85,7 @@ jobs:
           - v3.19
     steps:
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: jirutka/setup-alpine@v1
         with:
           branch: ${{ matrix.alpine }}
@@ -101,7 +101,7 @@ jobs:
             patchelf
             upx
       - name: Nuitka ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.nuitka
           key: ${{ github.job }}-ccache-alpine-${{ matrix.alpine }}
@@ -109,7 +109,7 @@ jobs:
         shell: alpine.sh {0}
         run: |
           make executable
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: rmufuse-alpine
           path: dist
@@ -120,13 +120,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
       - name: Nuitka ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.nuitka
           key: ${{ github.job }}-ccache-remarkable-2.15.1
@@ -150,7 +150,7 @@ jobs:
             fi
           done
         working-directory: ${{ github.workspace }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: rmufuse-remarkable
           path: dist
@@ -183,15 +183,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python:
-          - "3.11"
-          - "3.12"
-          - "3.13"
+        python: *python-versions
     steps:
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
@@ -202,17 +199,38 @@ jobs:
           script=$(cat <<EOF
           cd /src;
           export PATH=\$PATH:/opt/python/$python_version-$python_version/bin;
-          make ${{ env.FLAGS }} wheel;
+          make ${{ env.FLAGS }} native-wheel;
           auditwheel repair dist/*.whl;
           EOF
           )
           docker run -v $(pwd):/src \
             quay.io/pypa/manylinux_2_34_x86_64:latest \
             /bin/bash -c "$script"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pip-wheel-${{ matrix.python }}
           path: wheelhouse/*
+          if-no-files-found: error
+  build-any-wheel:
+    name: Build wheel
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+    steps:
+      - name: Checkout the Git repository
+        uses: actions/checkout@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install build tool
+        run: pip install build
+      - name: Building package
+        run: make wheel
+      - uses: actions/upload-artifact@v6
+        with:
+          name: pip-wheel-none-any
+          path: dist/*
           if-no-files-found: error
   build-sdist:
     name: Build sdist
@@ -220,9 +238,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -230,7 +248,7 @@ jobs:
         run: pip install build
       - name: Building package
         run: make sdist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pip-sdist
           path: dist/*
@@ -241,14 +259,8 @@ jobs:
     needs:
       - build-sdist
       - build-wheel
+      - build-any-wheel
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        artifact:
-          - "pip-sdist"
-          - "pip-wheel-3.11"
-          - "pip-wheel-3.12"
-          - "pip-wheel-3.13"
     permissions:
       id-token: write
       contents: write
@@ -258,9 +270,10 @@ jobs:
     steps:
       - name: Download pip packages
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.artifact }}
+          pattern: pip-*
+          merge-multiple: true
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -274,42 +287,22 @@ jobs:
       - build-executable-alpine
       - build-executable-remarkable
       - build-wheel
+      - build-any-wheel
       - build-sdist
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        artifact:
-          - "rmufuse-ubuntu"
-          - "rmufuse-alpine"
-          - "rmufuse-remarkable"
-          - "pip-sdist"
-          - "pip-wheel-3.11"
-          - "pip-wheel-3.12"
-          - "pip-wheel-3.13"
     permissions:
       contents: write
     steps:
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
-      - name: Download executable
+        uses: actions/checkout@v6
+      - name: Download pip packages
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.artifact }}
-          path: dist
+          pattern: pip-*
+          merge-multiple: true
       - name: Upload to release
-        run: |
-          if [ -f rmufuse ]; then
-            name="rmufuse-${{ matrix.artifact }}"
-            mv rmufuse "$name"
-            gh release upload "$TAG" "$name" --clobber
-          elif [ -f rmufuse-portable ]; then
-            name="rmufuse-${{ matrix.artifact }}"
-            mv rmufuse-portable "$name"
-            gh release upload "$TAG" "$name" --clobber
-          else
-            find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
-          fi
+        run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,8 +243,6 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - name: Install build tool
-        run: pip install build
       - name: Building package
         run: make wheel
       - uses: actions/upload-artifact@v6
@@ -264,8 +262,6 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - name: Install build tool
-        run: pip install build
       - name: Building package
         run: make sdist
       - uses: actions/upload-artifact@v6
@@ -316,26 +312,26 @@ jobs:
       - name: Checkout the Git repository
         uses: actions/checkout@v6
       - name: Download pip packages
-        id: download-pip
+        id: packages
         uses: actions/download-artifact@v8
         with:
           pattern: pip-*
           merge-multiple: true
-      - name: Download pip packages
-        id: download-rmufuse
+      - name: Download executables
+        id: executables
         uses: actions/download-artifact@v8
         with:
           pattern: rmufuse-*
           merge-multiple: true
-      - name: Upload to release
+      - name: Upload pip packages to release
         run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
-        working-directory: ${{ steps.download-pip.outputs.download-path }}
-      - name: Upload to release
+        working-directory: ${{ steps.packages.outputs.download-path }}
+      - name: Upload executables to release
         run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
-        working-directory: ${{ steps.download-rmufuse.outputs.download-path }}
+        working-directory: ${{ steps.executables.outputs.download-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,22 @@ on:
     types: [released]
 permissions: read-all
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug flags
+        shell: bash
+        if: runner.debug == '1'
+        run: echo 'FLAGS=-d' >> "$GITHUB_ENV"
+      - name: Checkout the Git repository
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Lint code
+        run: make lint format
   test:
     name: Test with python ${{ matrix.python }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,7 @@ jobs:
           python_version=${{ matrix.python }}
           python_version=cp${python_version//.}
           script=$(cat <<EOF
+          dnf install fuse-devel
           cd /src;
           export PATH=\$PATH:/opt/python/$python_version-$python_version/bin;
           make ${{ env.FLAGS }} native-wheel;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,9 @@ jobs:
     steps:
       - name: Install Apt packages
         id: cache-apt
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: Eeems-Org/apt-cache-action@v1
         with:
-          execute_install_scripts: true
           packages: libfuse-dev
-          version: 1.0
       - name: Checkout the Git repository
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+      fail-fast: false
     steps:
       - name: Install Apt packages
         id: cache-apt
@@ -65,6 +66,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+      fail-fast: false
     steps:
       - name: Install Apt packages
         id: cache-apt
@@ -99,6 +101,7 @@ jobs:
       matrix:
         alpine:
           - v3.19
+      fail-fast: false
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v6
@@ -200,6 +203,7 @@ jobs:
     strategy:
       matrix:
         python: *python-versions
+      fail-fast: false
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build: wheel
 release: wheel sdist
 
 .PHONY: install
-install: wheel
+install: native-wheel
 	if type pipx > /dev/null; then \
 	    pipx install \
 	        --force \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ clean:
 build: wheel
 
 .PHONY: release
-release: wheel sdist
+release: native-wheel wheel sdist
 
 .PHONY: install
 install: native-wheel

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ $(VENV_BIN_ACTIVATE): requirements.txt
 	python -m venv .venv
 	. $(VENV_BIN_ACTIVATE); \
 	python -m pip install wheel ruff build; \
-	python -m pip install -r requirements.txt
+	python -m pip install --extra-index-url=https://wheels.eeems.codes/ -r requirements.txt
 
 
 .venv/codexctl.zip: $(VENV_BIN_ACTIVATE)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ OBJ := $(shell find ${PACKAGE} -type f)
 OBJ += requirements.txt
 OBJ += pyproject.toml
 OBJ += README.md
+OBJ += LICENSE
 
 define PLATFORM_SCRIPT
 from sysconfig import get_platform

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,12 @@ wheel: dist/${PACKAGE}-${VERSION}-py3-none-any.whl
 dist:
 	mkdir -p dist
 
-dist/${PACKAGE}-${VERSION}.tar.gz: dist $(OBJ)
+dist/${PACKAGE}-${VERSION}.tar.gz: ${VENV_BIN_ACTIVATE} dist $(OBJ)
+	. ${VENV_BIN_ACTIVATE}; \
 	python -m build --sdist
 
-dist/${PACKAGE}-${VERSION}-${ABI}-${ABI}-${PLATFORM}.whl: dist $(OBJ)
+dist/${PACKAGE}-${VERSION}-${ABI}-${ABI}-${PLATFORM}.whl: ${VENV_BIN_ACTIVATE} dist $(OBJ)
+	. ${VENV_BIN_ACTIVATE}; \
 	python -m build --wheel
 
 dist/${PACKAGE}-${VERSION}-py3-none-any.whl: ${VENV_BIN_ACTIVATE} dist $(OBJ)
@@ -146,7 +148,7 @@ $(VENV_BIN_ACTIVATE): requirements.txt
 	@echo "Setting up development virtual env in .venv"
 	python -m venv .venv
 	. $(VENV_BIN_ACTIVATE); \
-	python -m pip install wheel ruff; \
+	python -m pip install wheel ruff build; \
 	python -m pip install -r requirements.txt
 
 
@@ -202,7 +204,7 @@ lint: $(VENV_BIN_ACTIVATE)
 .PHONY: lint-fix
 lint-fix: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
-	python -m ruff check
+	python -m ruff check --fix
 
 .PHONY: format
 format: $(VENV_BIN_ACTIVATE)

--- a/Makefile
+++ b/Makefile
@@ -87,15 +87,22 @@ dist:
 
 dist/${PACKAGE}-${VERSION}.tar.gz: ${VENV_BIN_ACTIVATE} dist $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
-	python -m build --sdist
+	PIP_EXTRA_INDEX_URL=https://wheels.eeems.codes/ \
+	python -m build \
+	  --sdist
 
 dist/${PACKAGE}-${VERSION}-${ABI}-${ABI}-${PLATFORM}.whl: ${VENV_BIN_ACTIVATE} dist $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
-	python -m build --wheel
+	PIP_EXTRA_INDEX_URL=https://wheels.eeems.codes/ \
+	python -m build \
+	  --wheel
 
 dist/${PACKAGE}-${VERSION}-py3-none-any.whl: ${VENV_BIN_ACTIVATE} dist $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
-	python -m build --wheel --config-setting=build_with_nuitka=false
+	PIP_EXTRA_INDEX_URL=https://wheels.eeems.codes/ \
+	python -m build \
+	  --wheel \
+	  --config-setting=build_with_nuitka=false
 
 dist/rmufuse: dist $(VENV_BIN_ACTIVATE) $(OBJ)
 	. $(VENV_BIN_ACTIVATE); \

--- a/Makefile
+++ b/Makefile
@@ -45,16 +45,20 @@ ifeq ($(VENV_BIN_ACTIVATE),)
 VENV_BIN_ACTIVATE := .venv/bin/activate
 endif
 
+.PHONY: clean
 clean:
 	if [ -d .venv/mnt ] && mountpoint -q .venv/mnt; then \
 		umount -ql .venv/mnt; \
 	fi
 	git clean --force -dX
 
+.PHONY: build
 build: wheel
 
+.PHONY: release
 release: wheel sdist
 
+.PHONY: install
 install: wheel
 	if type pipx > /dev/null; then \
 	    pipx install \
@@ -69,9 +73,14 @@ install: wheel
 	        ${PACKAGE}; \
 	fi
 
+.PHONY: sdist
 sdist: dist/${PACKAGE}-${VERSION}.tar.gz
 
-wheel: dist/${PACKAGE}-${VERSION}-${ABI}-${ABI}-${PLATFORM}.whl
+.PHONY: native-wheel
+native-wheel: dist/${PACKAGE}-${VERSION}-${ABI}-${ABI}-${PLATFORM}.whl
+
+.PHONY: wheel
+wheel: dist/${PACKAGE}-${VERSION}-py3-none-any.whl
 
 dist:
 	mkdir -p dist
@@ -81,6 +90,10 @@ dist/${PACKAGE}-${VERSION}.tar.gz: dist $(OBJ)
 
 dist/${PACKAGE}-${VERSION}-${ABI}-${ABI}-${PLATFORM}.whl: dist $(OBJ)
 	python -m build --wheel
+
+dist/${PACKAGE}-${VERSION}-py3-none-any.whl: ${VENV_BIN_ACTIVATE} dist $(OBJ)
+	. ${VENV_BIN_ACTIVATE}; \
+	python -m build --wheel --config-setting=build_with_nuitka=false
 
 dist/rmufuse: dist $(VENV_BIN_ACTIVATE) $(OBJ)
 	. $(VENV_BIN_ACTIVATE); \
@@ -134,7 +147,7 @@ $(VENV_BIN_ACTIVATE): requirements.txt
 	python -m venv .venv
 	. $(VENV_BIN_ACTIVATE); \
 	python -m pip install wheel ruff; \
-	python -m pip install --extra-index-url=https://wheels.eeems.codes/ -r requirements.txt
+	python -m pip install -r requirements.txt
 
 
 .venv/codexctl.zip: $(VENV_BIN_ACTIVATE)
@@ -153,6 +166,7 @@ $(VENV_BIN_ACTIVATE): requirements.txt
 .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed: .venv/bin/codexctl
 	.venv/bin/codexctl download --hardware rm2 --out .venv ${FW_VERSION}
 
+.PHONY: dev
 dev: $(VENV_BIN_ACTIVATE) .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed  $(OBJ)
 	if [ -d .venv/mnt ] && mountpoint -q .venv/mnt; then \
 		umount -ql .venv/mnt; \
@@ -165,46 +179,37 @@ dev: $(VENV_BIN_ACTIVATE) .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed  $(O
 	    .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed \
 	    .venv/mnt
 
+.PHONY: test
 test: $(VENV_BIN_ACTIVATE) .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed $(OBJ)
 	. $(VENV_BIN_ACTIVATE); \
 	python test.py
 
+.PHONY: executable
 executable: dist/rmufuse
 	dist/rmufuse --help
 
+.PHONY: portable
 portable: dist/rmufuse-portable
 
+.PHONY: all
 all: release
 
+.PHONY: lint
 lint: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff check
 
+.PHONY: lint-fix
 lint-fix: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff check
 
+.PHONY: format
 format: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff format --diff
 
+.PHONY: format-fix
 format-fix: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff format
-
-.PHONY: \
-	all \
-	build \
-	clean \
-	dev \
-	executable \
-	portable \
-	install \
-	release \
-	sdist \
-	wheel \
-	test \
-	lint \
-	lint-fix \
-	format \
-	format-fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ dependencies = {file = ["requirements.txt"]}
 readme = {file= ["README.md"], content-type = "text/markdown"}
 
 [build-system]
-requires = ["setuptools>=42", "wheel", "nuitka"]
+requires = ["setuptools>=77.1", "wheel", "nuitka"]
 build-backend = "nuitka.distutils.Build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ authors = [
 ]
 description = "Userspace filesystem for remarkable update files"
 requires-python = ">=3.11,<3.14"
+license = "MIT"
+license-files=["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remarkable_update_fuse"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
   { name="Eeems", email="eeems@eeems.email" },
 ]
@@ -10,7 +10,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fuse-python==1.0.9
-remarkable-update-image==1.3.2
+remarkable-update-image==1.3.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 1.3.3 and added MIT license metadata.
  * Updated dependency pin: remarkable-update-image → 1.3.3.

* **CI**
  * Added a lint job, modernized workflow actions and caching, and disabled matrix fail-fast.
  * Added a dedicated universal-wheel build job, consolidated artifact merging/downloads, and removed one executable build from the workflow.
  * Standardized executable artifact naming and uploads.

* **Build**
  * Produces both a universal wheel and a native/platform wheel; install and release flows updated.
  * Venv setup installs build tooling and lint-fix now auto-fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->